### PR TITLE
FIO-9199: add acorn to global scope

### DIFF
--- a/interpreter.js
+++ b/interpreter.js
@@ -5101,6 +5101,7 @@ Interpreter.prototype['stepWhileStatement'] =
 // Preserve top-level API functions from being pruned/renamed by JS compilers.
 // Add others as needed.
 Interpreter.nativeGlobal['Interpreter'] = Interpreter;
+Interpreter.nativeGlobal.acorn = acorn;
 Interpreter.prototype['step'] = Interpreter.prototype.step;
 Interpreter.prototype['run'] = Interpreter.prototype.run;
 Interpreter.prototype['appendCode'] = Interpreter.prototype.appendCode;


### PR DESCRIPTION
Added the acorn object to the global scope. This is similar to the fix in the npm repository of js-interpreter https://github.com/aminmarashi/JS-Interpreter